### PR TITLE
fix init, fix macOS globals, add macOS args, add args + parse_int example

### DIFF
--- a/examples/add_args.cal
+++ b/examples/add_args.cal
@@ -1,0 +1,15 @@
+include "cores/select.cal"
+include "std/args.cal"
+include "std/conv.cal"
+include "std/io.cal"
+
+if get_args_length 3 < then
+	"Required parameters: a b\n" printstr
+	1 exit
+end
+
+let Array arg
+1 &arg get_arg &arg parse_int
+2 &arg get_arg &arg parse_int
++ printdec new_line
+

--- a/source/backends/x86_64.d
+++ b/source/backends/x86_64.d
@@ -198,7 +198,7 @@ class BackendX86_64 : CompilerBackend {
 				break;
 			}
 			case "osx": {
-				ret ~= ["OSX", "IO", "Exit"];
+				ret ~= ["OSX", "IO", "Args", "Exit"];
 				break;
 			}
 			default: break;
@@ -337,7 +337,7 @@ class BackendX86_64 : CompilerBackend {
 		}
 
 		if (useLibc)          output ~= "global main\n";
-		else if (os == "osx") output ~= "global _main\n";
+		else if (os == "osx") output ~= "default rel\nglobal _main\n";
 		else                  output ~= "global _start\n";
 		
 		output ~= "section .text\n";
@@ -406,7 +406,6 @@ class BackendX86_64 : CompilerBackend {
 
 		// run init function
 		output ~= "__init:\n";
-		output ~= "mov rsi, rsp\n";
 		if ("__x86_64_program_init" in words) {
 			CallFunction("__x86_64_program_init");
 		}
@@ -1137,8 +1136,9 @@ class BackendX86_64 : CompilerBackend {
 			auto var = globals[node.func];
 
 			output ~= format(
-				"mov qword [r15], qword __global_%s\n", node.func.Sanitise()
+				"lea rax, qword [__global_%s]\n", node.func.Sanitise()
 			);
+			output ~= "mov [r15], rax\n";
 			output ~= "add r15, 8\n";
 		}
 		else if (VariableExists(node.func)) {


### PR DESCRIPTION
Just a bunch of changes that came up while adding Callisto to my [tak repo](https://github.com/soxfox42/tak).

- `rsp` was being saved to `rsi` inside of `__init` instead of outside. This caused two issues. Linux libc `argv` handling was broken because `rsi` was overwritten before `__x86_64_program_init`, and Linux no-libc `argv` handling was broken because `rsi` was off by 8 bytes because of the `__init` return address.

  Because `__x86_64_program_init` is inlined anyway, I just removed the saved stack pointer and accounted for the offset manually. The alternative would be to save the stack pointer before `call __init`, but a different register would need to be used to avoid the first issue.

- Marked macOS core as supporting `Args` feature (implemented in std PR).
- Fixed globals failing to assemble on macOS due to use of absolute addressing.

  Most of this is accomplished with `default rel`, which tells NASM to use RIP-relative addressing wherever possible, but I also had to manually fix `CompileAddr` to generate `lea + mov` instead of just `mov`. This works fine on Linux too.

- Added `add_args` example. This is basically the program I used while testing `Args` on macOS and the `parse_int` function, and I figured it was a nice example to have.