### PR TITLE
Fix errors on arm64

### DIFF
--- a/source/backends/arm64.d
+++ b/source/backends/arm64.d
@@ -586,7 +586,7 @@ class BackendARM64 : CompilerBackend {
 		if (node.inline) {
 			if (node.errors) {
 				LoadAddress("x9", "__global_" ~ Sanitise("_cal_exception"));
-				output ~= "ldr x10, #0\n";
+				output ~= "mov x10, #0\n";
 				output ~= "str x10, [x9]\n";
 			}
 
@@ -615,7 +615,7 @@ class BackendARM64 : CompilerBackend {
 
 			if (node.errors) {
 				LoadAddress("x9", "__global_" ~ Sanitise("_cal_exception"));
-				output ~= "ldr x10, #0\n";
+				output ~= "mov x10, #0\n";
 				output ~= "str x10, [x9]\n";
 			}
 


### PR DESCRIPTION
Code was initialising the exception global to a nonsense value because `ldr x10, #0` loads `x10` from `pc + 0`.