### PR TITLE
Fix macOS linking + argv

### DIFF
--- a/source/backends/x86_64.d
+++ b/source/backends/x86_64.d
@@ -202,7 +202,6 @@ class BackendX86_64 : CompilerBackend {
 
 		if (os == "osx") {
 			linkCommand ~= " -platform_version macos 10.6 `xcrun --sdk macosx --show-sdk-version`";
-			linkCommand ~= " -ld_classic -no_pie -e _main";
 			linkCommand ~= " -lSystem -syslibroot `xcrun --sdk macosx --show-sdk-path`";
 		}
 
@@ -497,7 +496,7 @@ class BackendX86_64 : CompilerBackend {
 		}
 
 		// create array source
-		output ~= format("%ssection .text\n", useGas? "." : "");
+		output ~= format("%ssection .rodata\n", useGas? "." : "");
 		foreach (i, ref array ; arrays) {
 			output ~= format("__array_src_%d: ", i);
 

--- a/source/backends/x86_64.d
+++ b/source/backends/x86_64.d
@@ -496,7 +496,7 @@ class BackendX86_64 : CompilerBackend {
 		}
 
 		// create array source
-		output ~= format("%ssection .rodata\n", useGas? "." : "");
+		output ~= format("%ssection .data\n", useGas? "." : "");
 		foreach (i, ref array ; arrays) {
 			output ~= format("__array_src_%d: ", i);
 


### PR DESCRIPTION
Moving array data to `.rodata` means I can throw away some linker arguments that were used to work around position-independence issues. Also this is the logical place for it IMO.

Also now the executable will run the libSystem startup code that manages `argv`.

You'll probably want to test that the `.rodata` change is fine on x86_64 Linux, I was too lazy 😆

update: `s/rodata/data`